### PR TITLE
Handle sudo for non-root user

### DIFF
--- a/scripts/deploy-webhook.sh
+++ b/scripts/deploy-webhook.sh
@@ -44,20 +44,25 @@ fi
 
 # Create remote directory
 print_status "Creating remote directory..."
-ssh "$SERVER_USER@$SERVER_HOST" "mkdir -p $REMOTE_DIR/scripts"
+ssh "$SERVER_USER@$SERVER_HOST" "sudo su - -c 'mkdir -p $REMOTE_DIR/scripts'"
 
-# Copy webhook files
+# Copy webhook files to temporary location first
 print_status "Copying webhook files..."
-scp scripts/webhook-handler.js "$SERVER_USER@$SERVER_HOST:$REMOTE_DIR/scripts/"
-scp scripts/setup-webhook.sh "$SERVER_USER@$SERVER_HOST:$REMOTE_DIR/scripts/"
+scp scripts/webhook-handler.js "$SERVER_USER@$SERVER_HOST:/tmp/"
+scp scripts/setup-webhook.sh "$SERVER_USER@$SERVER_HOST:/tmp/"
+
+# Move files to final location with root access
+print_status "Moving files to final location..."
+ssh "$SERVER_USER@$SERVER_HOST" "sudo su - -c 'mv /tmp/webhook-handler.js $REMOTE_DIR/scripts/'"
+ssh "$SERVER_USER@$SERVER_HOST" "sudo su - -c 'mv /tmp/setup-webhook.sh $REMOTE_DIR/scripts/'"
 
 # Make scripts executable
 print_status "Setting up scripts..."
-ssh "$SERVER_USER@$SERVER_HOST" "chmod +x $REMOTE_DIR/scripts/*.sh"
+ssh "$SERVER_USER@$SERVER_HOST" "sudo su - -c 'chmod +x $REMOTE_DIR/scripts/*.sh'"
 
 # Run setup script
 print_status "Running setup script..."
-ssh "$SERVER_USER@$SERVER_HOST" "cd $REMOTE_DIR && ./scripts/setup-webhook.sh"
+ssh "$SERVER_USER@$SERVER_HOST" "sudo su - -c 'cd $REMOTE_DIR && ./scripts/setup-webhook.sh'"
 
 # Test webhook endpoint
 print_status "Testing webhook endpoint..."
@@ -78,6 +83,6 @@ echo "3. Add the webhook secret (shown during setup)"
 echo "4. Select 'Just the push event'"
 echo ""
 echo "🔧 Useful commands:"
-echo "  Check service status: ssh $SERVER_USER@$SERVER_HOST 'systemctl status sharedrop-webhook'"
-echo "  View logs: ssh $SERVER_USER@$SERVER_HOST 'journalctl -u sharedrop-webhook -f'"
-echo "  Restart service: ssh $SERVER_USER@$SERVER_HOST 'systemctl restart sharedrop-webhook'" 
+echo "  Check service status: ssh $SERVER_USER@$SERVER_HOST 'sudo su - -c \"systemctl status sharedrop-webhook\"'"
+echo "  View logs: ssh $SERVER_USER@$SERVER_HOST 'sudo su - -c \"journalctl -u sharedrop-webhook -f\"'"
+echo "  Restart service: ssh $SERVER_USER@$SERVER_HOST 'sudo su - -c \"systemctl restart sharedrop-webhook\"'" 


### PR DESCRIPTION
Update `deploy-webhook.sh` to use `sudo su -` for operations requiring root access, enabling deployment on servers without direct root login.

---
<a href="https://cursor.com/background-agent?bcId=bc-12ec1b6b-3154-430c-ae88-c206264dc4e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12ec1b6b-3154-430c-ae88-c206264dc4e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

